### PR TITLE
Update for pyfastnet>=2.0.1 channel dict API change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Connections
 
 I have been running on Rasperry Pi, a stock install is sufficient.
 
-```pip3 install pyfastnet```
+```pip3 install "pyfastnet>=2.0.1"```
 
 
 ## Running

--- a/fastnet2ip.py
+++ b/fastnet2ip.py
@@ -752,8 +752,9 @@ def process_frame_queue(frame_queue, udp_socket, udp_port):
                 if not channel_data:
                     continue
 
-                channel_id        = channel_data.get("channel_id", "??")
-                interpreted_value = channel_data.get("interpreted", "N/A")
+                channel_id = channel_data.get("channel_id", "??")
+                value      = channel_data.get("value")
+                interpreted_value = value if value is not None else channel_data.get("display_text", "N/A")
 
                 # --- peek at old entry
                 with live_data_lock:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 pyserial>=3.5
-pyfastnet
+pyfastnet>=2.0.1


### PR DESCRIPTION
pyfastnet 2.0.1 simplified the decoded channel dict from {interpreted, ...} to {value, display_text, layout}. Use numeric value when available, falling back to display_text for text-only channels (e.g. LatLon).

Pin pyfastnet>=2.0.1 in requirements.txt and README install command.